### PR TITLE
Add a link to scalar types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @okgrow/graphql-scalars
 
-A library of custom GraphQL scalar types for creating precise type-safe GraphQL schemas.
+A library of custom GraphQL [scalar types](http://graphql.org/learn/schema/#scalar-types) for creating precise type-safe GraphQL schemas.
 
 
 ## Installation


### PR DESCRIPTION
I didn't know what these are. This may help people in the future. It's a small add that doesn't affect the meaning at all, but may help adoption.