### PR TITLE
Support numeric date format

### DIFF
--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -42,20 +42,20 @@ export default new GraphQLScalarType({
   },
 
   parseLiteral(ast) {
-    if (ast.kind !== Kind.STRING) {
+    if (ast.kind !== Kind.STRING && ast.kind !== Kind.INT) {
       throw new GraphQLError(
-        `Can only parse strings to dates but got a: ${ast.kind}`,
+        `Can only parse strings & integers to dates but got a: ${ast.kind}`,
       );
     }
 
-    const result = new Date(ast.value);
+    const result = new Date(ast.kind === Kind.INT ? Number(ast.value) : ast.value);
 
     // eslint-disable-next-line no-restricted-globals
     if (Number.isNaN(result.getTime())) {
       throw new GraphQLError(`Value is not a valid Date: ${ast.value}`);
     }
 
-    if (ast.value !== result.toJSON()) {
+    if (ast.kind === Kind.STRING && ast.value !== result.toJSON()) {
       throw new GraphQLError(
         `Value is not a valid Date format (YYYY-MM-DDTHH:MM:SS.SSSZ): ${
           ast.value

--- a/src/DateTime.js
+++ b/src/DateTime.js
@@ -10,9 +10,9 @@ export default new GraphQLScalarType({
   serialize(value) {
     let v = value;
 
-    if (!(v instanceof Date) && typeof v !== 'string') {
+    if (!(v instanceof Date) && typeof v !== 'string' && typeof v !== 'number') {
       throw new TypeError(
-        `Value is not an instance of Date or Date string: ${v}`,
+        `Value is not an instance of Date, Date string or number: ${v}`,
       );
     }
 
@@ -20,6 +20,8 @@ export default new GraphQLScalarType({
       v = new Date();
 
       v.setTime(Date.parse(value));
+    } else if (typeof v === 'number') {
+      v = new Date(v);
     }
 
     // eslint-disable-next-line no-restricted-globals

--- a/src/__tests__/DateTime.test.js
+++ b/src/__tests__/DateTime.test.js
@@ -34,6 +34,13 @@ describe('DateTime', () => {
           kind: Kind.STRING,
         }),
       ).toEqual(result);
+
+      expect(
+        DateTime.parseLiteral({
+          value: result.getTime().toString(),
+          kind: Kind.INT,
+        }),
+      ).toEqual(result);
     });
   });
 

--- a/src/__tests__/DateTime.test.js
+++ b/src/__tests__/DateTime.test.js
@@ -21,6 +21,12 @@ describe('DateTime', () => {
       expect(DateTime.serialize(now)).toEqual(d2.toJSON());
     });
 
+    test('serialize (number)', () => {
+      const now = new Date();
+
+      expect(DateTime.serialize(now.getTime())).toEqual(now.toJSON());
+    });
+
     test('parseValue', () => {
       const now = new Date();
       expect(DateTime.parseValue(now)).toEqual(now);


### PR DESCRIPTION
Adds support for parsing & serialising numeric dates. It uses the standard JS format of milliseconds since the unix epoch, as this is the native format Date supports.